### PR TITLE
[FIX] currency_rate_update_nbp : Update url to retrieve rates

### DIFF
--- a/currency_rate_update_nbp/models/res_currency_rate_provider_nbp.py
+++ b/currency_rate_update_nbp/models/res_currency_rate_provider_nbp.py
@@ -85,7 +85,7 @@ class ResCurrencyRateProviderNBP(models.Model):
             )  # pragma: no cover
 
         # LastA.xml is always the most recent one
-        url = "http://www.nbp.pl/kursy/xml/LastA.xml"
+        url = "https://static.nbp.pl/dane/kursy/xml/LastA.xml"
         content = requests.get(url, timeout=5).content
 
         dom = etree.fromstring(content)


### PR DESCRIPTION
Url has changed is old one is not active anymore, see : 
https://nbp.pl/en/statistic-and-financial-reporting/rates/the-instruction-how-to-retrieve-currency-exchange-rates-from-the-nbp-website
@TadeuszKarpinski I guess it may impact you as well, FYI
